### PR TITLE
Fix VRChat Photo Camera crash

### DIFF
--- a/Scripts/GaussianSplatRenderer.cs
+++ b/Scripts/GaussianSplatRenderer.cs
@@ -608,11 +608,11 @@ public class GaussianSplatRenderer : UdonSharpBehaviour
         {
             VRCCameraSettings.ScreenCamera.AllowMSAA = false;
         }
-
-        if (VRCCameraSettings.PhotoCamera != null)
-        {
-            VRCCameraSettings.PhotoCamera.AllowMSAA = false;
-        }
+        // Commented out to prevent the VRChat Photo Camera from crashing!
+       // if (VRCCameraSettings.PhotoCamera != null)
+       // {
+       //     VRCCameraSettings.PhotoCamera.AllowMSAA = false;
+       // }
     }
 
     void Start()


### PR DESCRIPTION
Prevented the script from forcing PhotoCamera MSAA to false, which was passing an invalid 0 value to RenderTexture.GetTemporary and breaking the in-game camera.